### PR TITLE
sanbox

### DIFF
--- a/Graphite/Core/ScriptController/ScriptController.cpp
+++ b/Graphite/Core/ScriptController/ScriptController.cpp
@@ -230,7 +230,7 @@ void Graphite::ScriptLoader::init() {
         int status = 0; 
         waitpid(pid, &status, 0);
 
-        if (!WIFEXITED(status) || !WEXITSTATUS(status) == 0) { 
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) { 
           if(verbose_mode){
             printf("%d\n", status);
             printf("Init failed!\n");
@@ -264,7 +264,7 @@ void Graphite::ScriptLoader::update() {
         int status = 0; 
         waitpid(pid, &status, 0);
 
-        if (!WIFEXITED(status) || !WEXITSTATUS(status) == 0) { 
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) { 
           if(verbose_mode){
             printf("%d\n", status);
             printf("Update failed!\n");
@@ -298,7 +298,7 @@ void Graphite::ScriptLoader::draw(){
         int status = 0; 
         waitpid(pid, &status, 0);
 
-        if (!WIFEXITED(status) || !WEXITSTATUS(status) == 0) { 
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) { 
           if(verbose_mode){
             printf("%d\n", status);
             printf("Draw failed!\n");
@@ -332,7 +332,7 @@ void Graphite::ScriptLoader::destroy() {
         int status = 0; 
         waitpid(pid, &status, 0);
 
-        if (!WIFEXITED(status) || !WEXITSTATUS(status) == 0) { 
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) { 
           if(verbose_mode){
             printf("%d\n", status);
             printf("Destroy failed!\n");


### PR DESCRIPTION
This pull request corrects the logic used to check the exit status of child processes in the `ScriptLoader` methods. The previous condition incorrectly checked for a successful exit, which could have caused failures to go undetected. The updated condition now properly detects when a child process fails, improving error handling and reliability in the `init`, `update`, `draw`, and `destroy` methods.

Error handling improvements in process exit status checks:

* Fixed the exit status check in `ScriptLoader::init()` to correctly detect failed child processes by changing the condition from `!WEXITSTATUS(status) == 0` to `WEXITSTATUS(status) != 0`.
* Applied the same fix to `ScriptLoader::update()` for accurate process failure detection.
* Updated `ScriptLoader::draw()` to use the corrected exit status check logic.
* Updated `ScriptLoader::destroy()` with the same improved exit status check.